### PR TITLE
Fix Issue #5

### DIFF
--- a/zlc.el
+++ b/zlc.el
@@ -65,9 +65,9 @@
       :background "firebrick"
       :italic nil
       :bold t)))
-  nil
+  "Style of selected item in *Completions* buffer"
   :group 'zlc-face
-  "Style of selected item in *Completions* buffer")
+  )
 
 (defcustom zlc-select-completion-immediately nil
   "Non-nil to select completion immediately when completion list created."


### PR DESCRIPTION
Enable byte-compile and "(require 'zlc)" for Emacs >= 24.3

Signed-off-by: Youhei SASAKI uwabami@gfd-dennou.org
