### PR TITLE
Add new function to enter selected directory by hitting slash key

### DIFF
--- a/zlc.el
+++ b/zlc.el
@@ -201,6 +201,14 @@
   (interactive)
   (zlc-select-next-vertical -1))
 
+(defun zlc-enter-directory-by-slash ()
+  (interactive)
+  (if (and (equal (string (char-before)) "/")
+           (eq (point) (field-end)))
+      (zlc-minibuffer-complete)
+    (progn (insert "/")
+           (setq minibuffer-scroll-window nil))))
+
 (defmacro zlc--do-completion ()
   (if (eq (car (help-function-arglist 'completion--do-completion)) '&optional)
       '(completion--do-completion)
@@ -219,7 +227,8 @@ select completion orderly."
               (eq last-command 'zlc-select-previous)
               (eq last-command 'zlc-select-previous-vertical)
               (eq last-command 'zlc-select-next)
-              (eq last-command 'zlc-select-next-vertical))
+              (eq last-command 'zlc-select-next-vertical)
+              (eq last-command 'zlc-enter-directory-by-slash))
     (setq minibuffer-scroll-window nil))
   (let ((window minibuffer-scroll-window)
         completion-status)
@@ -278,7 +287,8 @@ With ARG, turn zlc on if arg is positive, off otherwise."
 
 (let ((map minibuffer-local-map))
   (define-key map (kbd "<backtab>") 'zlc-select-previous)
-  (define-key map (kbd "S-<tab>") 'zlc-select-previous))
+  (define-key map (kbd "S-<tab>") 'zlc-select-previous)
+  (define-key map (kbd "/") 'zlc-enter-directory-by-slash))
 
 (provide 'zlc)
 ;;; zlc.el ends here


### PR DESCRIPTION
When the current selected candidate is a directory, ZSH shows files in the directory by hitting the "/" key and doesn't add a new (redundant) slash to the minibuffer. Users can use the slash key to just choose the current candidate and see files in it.
This patch provides a new function to support the same behavior in ZLC. Currently, ZLC starts completion for another path when a directory is selected and the user enters a slash.