### PR TITLE
Show message when no completion candidates found

### DIFF
--- a/zlc.el
+++ b/zlc.el
@@ -235,7 +235,8 @@ select completion orderly."
                   ;; `minibuffer-message' is a blocking fucntion
                   (let (completion-show-inline-help)
                     (zlc--do-completion)))
-        (#b000 nil)
+        (#b000 (goto-char (field-end))
+               (minibuffer-message "No candidates found"))
         (#b001 (goto-char (field-end))
                (minibuffer-message "Sole completion")
                t)


### PR DESCRIPTION
Shows "No candidates found" when there are no files matching the provided pattern.